### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/magik-server/directorylisting.js
+++ b/lib/magik-server/directorylisting.js
@@ -1,5 +1,5 @@
 var bytes = require('bytes'),
-    ent = require('ent'),
+    he = require('he'),
     fs = require('fs'),
     fsPath = require('path');
 
@@ -135,7 +135,7 @@ module.exports = function(path, config, serverCallback) {
 
             // name
             html += '<td class="name">';
-            html += '<a href="'+fsPath.normalize(relativePath + '/' + file[0])+'">' + ent.encode(file[0]) + ((isDir)? '/':'') + '</a>';
+            html += '<a href="'+fsPath.normalize(relativePath + '/' + file[0])+'">' + he.encode(file[0]) + ((isDir)? '/':'') + '</a>';
             html += '</td>\n';
 
             // size

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "stylus": "^0.48.1",
     "less-middleware": "^1.0.4",
     "tiny-lr": "^0.1.1",
-    "ent": "^2.0.0"
+    "he": "^0.5.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](https://mths.be/he).
